### PR TITLE
[CSSPPIT-664] Change STS call from GET to POST

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -17,7 +17,7 @@ import (
 var (
 	// stsURL represents the AWS STS URL to enchange SAML assertion
 	// token for credentials
-	STSURL = "https://sts.amazonaws.com/oauth2/v1/token"
+	STSURL = "https://sts.amazonaws.com/"
 	// TODO: How does this works for windows?
 	CredentialsDirectory = ".aws"
 	CredentialsFileName  = "credentials"
@@ -59,6 +59,7 @@ type Provider struct {
 // httpClient defines the methods that the provider needs an http client to have
 type httpClient interface {
 	Get(r_url string, params map[string]string, body io.Reader) (*http.Response, error)
+	Post(r_url string, params map[string]string, headers map[string]string, body interface{}) (*http.Response, error)
 }
 
 // fileSystemManager defines the methods that the provider needs a file system

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -186,9 +186,9 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
-					GetBodyData:   []byte(SuccessSTSResponse),
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
+					PostBodyData:   []byte(SuccessSTSResponse),
 				},
 			},
 			expect: expect{
@@ -206,7 +206,7 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetErr: errors.New("error while doing request"),
+					PostErr: errors.New("error while doing request"),
 				},
 			},
 			expect: expect{
@@ -219,8 +219,8 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
 				},
 			},
 			expect: expect{
@@ -233,9 +233,9 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusBadRequest,
-					GetStatus:     "Bad Request",
-					GetBodyData:   []byte(errSTSResponse),
+					PostStatusCode: http.StatusBadRequest,
+					PostStatus:     "Bad Request",
+					PostBodyData:   []byte(errSTSResponse),
 				},
 			},
 			expect: expect{
@@ -248,9 +248,9 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusForbidden,
-					GetStatus:     "Forbidden",
-					GetBodyData:   []byte(errSTSResponse),
+					PostStatusCode: http.StatusForbidden,
+					PostStatus:     "Forbidden",
+					PostBodyData:   []byte(errSTSResponse),
 				},
 			},
 			expect: expect{
@@ -263,8 +263,8 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusInternalServerError,
-					GetStatus:     "Internal Serverl Error",
+					PostStatusCode: http.StatusInternalServerError,
+					PostStatus:     "Internal Server Error",
 				},
 			},
 			expect: expect{
@@ -277,9 +277,9 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
-					GetBodyData:   []byte(SuccessSTSResponse),
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
+					PostBodyData:   []byte(SuccessSTSResponse),
 				},
 				byteReader: func(io.Reader) ([]byte, error) { return nil, errors.New("response could not be read") },
 			},
@@ -293,9 +293,9 @@ func TestGetSTSCredentialsFromSAML(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
-					GetBodyData:   nil,
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
+					PostBodyData:   nil,
 				},
 			},
 			expect: expect{
@@ -494,9 +494,9 @@ func TestGenerateCredentials(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
-					GetBodyData:   []byte(SuccessSTSResponse),
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
+					PostBodyData:   []byte(SuccessSTSResponse),
 				},
 				mckFs: fsmanager.NewMock(),
 			},
@@ -510,9 +510,9 @@ func TestGenerateCredentials(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusForbidden,
-					GetStatus:     "Forbiddend",
-					GetBodyData:   []byte(errSTSResponse),
+					PostStatusCode: http.StatusForbidden,
+					PostStatus:     "Forbiddend",
+					PostBodyData:   []byte(errSTSResponse),
 				},
 				mckFs: fsmanager.NewMock(),
 			},
@@ -526,9 +526,9 @@ func TestGenerateCredentials(t *testing.T) {
 			opts: opts{
 				p: prf,
 				mckClient: client.MockHttpClient{
-					GetStatusCode: http.StatusOK,
-					GetStatus:     "OK",
-					GetBodyData:   []byte(SuccessSTSResponse),
+					PostStatusCode: http.StatusOK,
+					PostStatus:     "OK",
+					PostBodyData:   []byte(SuccessSTSResponse),
 				},
 				mckFs: fsmanager.MockFileSystem{
 					WriteErr: errors.New("pemission (to dance) denied"),

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -44,7 +44,7 @@ type stsError struct {
 func (p Provider) getSTSCredentialsFromSAML(saml string) (credentials, error) {
 	log.Print("getting STS credentials...")
 
-	params := map[string]string{
+	body := map[string]string{
 		"Version":       "2011-06-15",
 		"Action":        "AssumeRoleWithSAML",
 		"RoleArn":       p.Profile.RoleARN,
@@ -52,11 +52,15 @@ func (p Provider) getSTSCredentialsFromSAML(saml string) (credentials, error) {
 		"SAMLAssertion": saml,
 	}
 
-	resp, err := p.httpClient.Get(STSURL, params, nil)
-	defer resp.Body.Close()
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+
+	resp, err := p.httpClient.Post(STSURL, nil, headers, body)
 	if err != nil {
 		return credentials{}, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
+	defer resp.Body.Close()
 
 	respBody, err := ioReadAll(resp.Body)
 	if err != nil {

--- a/client/mock_client.go
+++ b/client/mock_client.go
@@ -8,10 +8,14 @@ import (
 )
 
 type MockHttpClient struct {
-	GetStatusCode int
-	GetStatus     string
-	GetBodyData   []byte
-	GetErr        error
+	GetStatusCode  int
+	GetStatus      string
+	GetBodyData    []byte
+	GetErr         error
+	PostStatusCode int
+	PostStatus     string
+	PostBodyData   []byte
+	PostErr        error
 }
 
 func (m MockHttpClient) Get(r_url string, params map[string]string, body io.Reader) (*http.Response, error) {
@@ -23,4 +27,15 @@ func (m MockHttpClient) Get(r_url string, params map[string]string, body io.Read
 			Method: http.MethodGet,
 		},
 	}, m.GetErr
+}
+
+func (m MockHttpClient) Post(postUrl string, params map[string]string, headers map[string]string, body interface{}) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.PostStatusCode,
+		Status:     fmt.Sprintf("%d : %s", m.PostStatusCode, m.PostStatus),
+		Body:       io.NopCloser(bytes.NewBuffer(m.PostBodyData)),
+		Request: &http.Request{
+			Method: http.MethodPost,
+		},
+	}, m.PostErr
 }


### PR DESCRIPTION
## Description
Change request to STS' AssumeRole request from GET to POST to avoid security vulnerabilities. New request encodes the values in the body with `x-www-form-urlencoded`  which is the only way a POST request works.

## How to test this ticket
1. The flow should work the same as before.
2. When monitoring network traffic, the request values should not be visible in the request URL. 

## Related tickets
[CSPPIT-664](https://foxjira.praecipio.com/browse/CSPPIT-664)